### PR TITLE
Fix "butracker" typo

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,7 +10,7 @@
   <license>BSD</license>
 
   <url type="website">https://github.com/davetcoleman/moveit_boilerplate</url>
-  <url type="butracker">https://github.com/davetcoleman/moveit_boilerplate/issues</url>
+  <url type="bugtracker">https://github.com/davetcoleman/moveit_boilerplate/issues</url>
   <url type="repository">https://github.com/davetcoleman/moveit_boilerplate/</url>
 
   <author email="davetcoleman@gmail.com">Dave Coleman</author>


### PR DESCRIPTION
I saw [this PR](https://github.com/ros-planning/moveit_visual_tools/pull/87) and wondered where it came from